### PR TITLE
Remove hollow on Add beneficiaries Button

### DIFF
--- a/src/js/beneficiaries.js
+++ b/src/js/beneficiaries.js
@@ -45,7 +45,7 @@ function addBeneficiariesButton(){
     var benef_button = document.createElement('input');
     benef_button.value = 'Add beneficiaries';
     benef_button.type='button';
-    benef_button.className = 'UserWallet__buysp button hollow benef';
+    benef_button.className = 'UserWallet__buysp button benef';
 
     benef_div.appendChild(benef_button);
     $('.vframe__section--shrink')[$('.vframe__section--shrink').length-1].after(benef_div);
@@ -55,7 +55,7 @@ function addBeneficiariesButton(){
         if($('.close').length===1) {
             $('.vframe__section--shrink button').hide();
             if($('.post').length===0) {
-                $('.beneficiaries').after('<li class="post"><div class="inline_button"><input type="button" class="UserWallet__buysp button hollow postbutton" value="Post"/></div></li>');
+                $('.beneficiaries').after('<li class="post"><div class="inline_button"><input type="button" class="UserWallet__buysp button postbutton" value="Post"/></div></li>');
                 $('.postbutton').click(function (){if(isEverythingFilled()) postBeneficiaries();});
                 }
                 else


### PR DESCRIPTION
The Steemit website in Night Mode features the "Add Beneficiaries" Mouse over button with the class "hollow". This causes the text on the button to have the same color as the background color of the button so you can't read the text.

![4483bbe8c404b7b4f51d4e0f434ee91d](https://user-images.githubusercontent.com/35930080/36621813-50be6a02-18fa-11e8-9bf1-e063973968b0.gif)

----
Removing "hollow" in the CSS class brings the white text you are used to when you click over the button.

![b51eafe74ce2c2344bd3c1caa7dbc0fa](https://user-images.githubusercontent.com/35930080/36621927-d6f48b10-18fa-11e8-93c6-4577ce9bbaa7.gif)
